### PR TITLE
feat(article): 프로필 내 게시글 목록 조회 API

### DIFF
--- a/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/application/ArticleService.kt
+++ b/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/application/ArticleService.kt
@@ -81,18 +81,16 @@ class ArticleService(
 
     @Transactional(readOnly = true)
     fun showAllByUserId(userId: Long): List<ArticleFeedResponse> {
-        val user = userRepository.findByIdOrNull(userId)
+        val articles = userRepository.findByIdOrNull(userId)
+            ?.let(articleRepository::findAllByAuthor)
             ?: EntityNotFoundException.notExistsId(User::class, userId)
 
-        return articleRepository.findAllByAuthor(user)
-            .map { article ->
-                val articleOptions = articleOptionRepository.findAllByArticle(article)
-                val articleFavorites = articleFavoriteRepository.findAllByArticle(article)
-
+        return articles
+            .map {
                 ArticleFeedResponse(
-                    article = article,
-                    articleOptions = articleOptions,
-                    articleFavorites = articleFavorites,
+                    article = it,
+                    articleOptions = articleOptionRepository.findAllByArticle(it),
+                    articleFavorites = articleFavoriteRepository.findAllByArticle(it),
                 )
             }
     }

--- a/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/application/ArticleService.kt
+++ b/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/application/ArticleService.kt
@@ -22,6 +22,7 @@ import com.devfloor.hongit.core.board.domain.Board
 import com.devfloor.hongit.core.board.domain.BoardRepository
 import com.devfloor.hongit.core.option.domain.OptionRepository
 import com.devfloor.hongit.core.user.domain.User
+import com.devfloor.hongit.core.user.domain.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -35,6 +36,7 @@ class ArticleService(
     private val boardRepository: BoardRepository,
     private val optionRepository: OptionRepository,
     private val articleViewCountRepository: ArticleViewCountRepository,
+    private val userRepository: UserRepository,
 
     private val articleHashtagService: ArticleHashtagService,
     private val articleOptionService: ArticleOptionService,
@@ -65,6 +67,24 @@ class ArticleService(
             ?: EntityNotFoundException.notExistsId(Board::class, boardId)
 
         return articleRepository.findAllByBoard(board)
+            .map { article ->
+                val articleOptions = articleOptionRepository.findAllByArticle(article)
+                val articleFavorites = articleFavoriteRepository.findAllByArticle(article)
+
+                ArticleFeedResponse(
+                    article = article,
+                    articleOptions = articleOptions,
+                    articleFavorites = articleFavorites,
+                )
+            }
+    }
+
+    @Transactional(readOnly = true)
+    fun showAllByUserId(userId: Long): List<ArticleFeedResponse> {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: EntityNotFoundException.notExistsId(User::class, userId)
+
+        return articleRepository.findAllByAuthor(user)
             .map { article ->
                 val articleOptions = articleOptionRepository.findAllByArticle(article)
                 val articleFavorites = articleFavoriteRepository.findAllByArticle(article)

--- a/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/presentation/ArticleController.kt
+++ b/hongit-api/src/main/kotlin/com/devfloor/hongit/api/article/presentation/ArticleController.kt
@@ -37,6 +37,11 @@ class ArticleController(
     fun showAllByBoardId(@RequestParam boardId: Long): List<ArticleFeedResponse> =
         articleService.showAllByBoardId(boardId)
 
+    @GetMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    fun showAllByUserId(@RequestParam userId: Long): List<ArticleFeedResponse> =
+        articleService.showAllByUserId(userId)
+
     @PostMapping
     fun create(@RequestBody request: ArticleCreateRequest, @LoginUser author: User): ResponseEntity<Unit> {
         val articleId = articleService.create(request, author)

--- a/hongit-core/src/main/kotlin/com/devfloor/hongit/core/article/domain/ArticleRepository.kt
+++ b/hongit-core/src/main/kotlin/com/devfloor/hongit/core/article/domain/ArticleRepository.kt
@@ -1,10 +1,13 @@
 package com.devfloor.hongit.core.article.domain
 
 import com.devfloor.hongit.core.board.domain.Board
+import com.devfloor.hongit.core.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 interface ArticleRepository : JpaRepository<Article, Long> {
     fun findAllByBoard(board: Board): List<Article>
+
+    fun findAllByAuthor(author: User): List<Article>
 }


### PR DESCRIPTION
### 상세 설명
- `showAllByBoardId`랑 로직이 비슷하고, 다른점은 Author로 조회하는지 BoardId로 조회하는지 정도가 다릅니다. URL 파라미터로 받는것에 따라, '같은 로직으로 들어가되, DB조회만 다르게' 구현하는 좋은 방법은 없을까 고민했는데, 잘 떠오르지 않네요. 혹시 이런 중복된 부분 하나의 로직으로 처리하는 그런 방법 없을까요?

closes #61 